### PR TITLE
Add subdomain tracking

### DIFF
--- a/site/.vitepress/config.js
+++ b/site/.vitepress/config.js
@@ -35,6 +35,7 @@ export default {
       `
         var _paq = window._paq = window._paq || [];
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setCookieDomain", "*.beamerbridge.com"]);
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {


### PR DESCRIPTION
We want to separate app.beamerbridge from beamerbridge.com within the tracking and this should allow for this.