### PR TITLE
Added subdomain tracking

### DIFF
--- a/site/.vitepress/config.js
+++ b/site/.vitepress/config.js
@@ -35,14 +35,17 @@ export default {
       `
         var _paq = window._paq = window._paq || [];
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+        _paq.push(["setCookieDomain", "*.beamerbridge.com"]);
+        _paq.push(["setDomains", ["*.beamerbridge.com"]]);
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {
-          var u="https://beamerbridge.matomo.cloud/";
-          _paq.push(['setTrackerUrl', u+'matomo.php']);
-          _paq.push(['setSiteId', '1']);
-          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-          g.async=true; g.src='//cdn.matomo.cloud/beamerbridge.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+        var u="https://beamerbridge.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+         g.async=true; g.src='//cdn.matomo.cloud/beamerbridge.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
         })();
     `,
     ],


### PR DESCRIPTION
Added:
- tracking visitors across all subdomains
- prepend the site domain to the page title when tracking
- outlines report hide clicks known alias URLS of beamer

based on https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains